### PR TITLE
Add 3.20.2 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "3.14",
     "3.16",
     "3.18",
-    "3.20"
+    "3.20",
+    "3.20.2"
   ],
   "url": "https://github.com/v-dimitrov/gnome-shell-extension-stealmyfocus",
   "uuid": "focus-my-window@varianto25.com",


### PR DESCRIPTION
I cannot install this extension from the [extensions.gnome.org](https://extensions.gnome.org/extension/1005/focus-my-window/) because I'm using `gnome-shell` version `3.20.2`.
