### PR TITLE
bump version to ship out compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,5 +15,5 @@
   ],
   "url": "https://github.com/v-dimitrov/gnome-shell-extension-stealmyfocus",
   "uuid": "focus-my-window@varianto25.com",
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
I am [packaging this extension for Arch Linux](https://aur.archlinux.org/packages/gnome-shell-extension-stealmyfocus-git/) and am very happy with the compatibility updates. As the package mirrors the version number from the meta data description, a version update would indicate a change to the package manager, issuing an update to all users.

As I suspect other distribution packages are manages similarly, I herewith suggest a version increment whenever a stable (even-numbered) `shell-version` is added.