### PR TITLE
add 42 to version compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
     "3.20.2",
     "3.21",
     "3.22",
-    "3.22.2"
+    "3.22.2",
+    "42"
   ],
   "url": "https://github.com/v-dimitrov/gnome-shell-extension-stealmyfocus",
   "uuid": "focus-my-window@varianto25.com",


### PR DESCRIPTION
Add version 42 for compatibility with Ubuntu 22.04 (and anything else using Gnome 42).