### PR TITLE
Add 41 to compatible versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,7 @@
     "3.21",
     "3.22",
     "3.22.2",
+    "41",
     "42"
   ],
   "url": "https://github.com/v-dimitrov/gnome-shell-extension-stealmyfocus",


### PR DESCRIPTION
GNOME 41 is still in use on Fedora 35 which is supported until approx 2022-11.

Tested working with gnome-shell-41.7