### PR TITLE
Add whitelist/blacklist window filtering and interactive window picker

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -18,18 +18,111 @@
     SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Inspector } from 'resource:///org/gnome/shell/ui/lookingGlass.js';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Meta from 'gi://Meta';
 
 export default class FocusMyWindow extends Extension {
     enable() {
-        this._handlerid = global.display.connect('window-demands-attention', function (display, window) {
+        this._settings = this.getSettings();
+        this._picker = new WindowPicker();
+        this._picker.export();
+        this._handlerid = global.display.connect('window-demands-attention',
+            (display, window) => this._onWindowDemandsAttention(window));
+    }
+
+    _onWindowDemandsAttention(window) {
+        const wmClass = window.wm_class?.toLowerCase() ?? '';
+        const whitelistEnabled = this._settings.get_boolean('whitelist-mode');
+        const windowList = this._settings.get_strv('window-list');
+
+        const isListed = windowList.some(pattern =>
+            wmClass.toLowerCase() === pattern.toLowerCase()
+        );
+
+        // if whitelist enabled && listed 
+        // or whitelist disabled && not listed
+        if (whitelistEnabled === isListed) {
             Main.activateWindow(window);
-        });
+        }
     }
 
     disable() {
         global.display.disconnect(this._handlerid);
+        this._picker.unexport();
         this._handlerid = null;
+        this._settings = null;
+        this._picker = null;
+    }
+}
+
+const DBusInterfaceScheme = `
+<node>
+  <interface name="org.gnome.Shell.Extensions.StealMyFocus">
+    <method name="pick" />
+    <signal name="picked">
+      <arg name="window" type="s" />
+    </signal>
+  </interface>
+</node>
+`;
+
+const NotFoundWindowString = "!!no-window-picked!!";
+const objectPath = '/org/gnome/shell/extensions/StealMyFocus';
+
+export class WindowPicker {
+    #dbus = Gio.DBusExportedObject.wrapJSObject(DBusInterfaceScheme, this);
+
+    #sendPickedWindow(wmClass) {
+        this.#dbus.emit_signal('picked', new GLib.Variant('(s)', [wmClass]));
+    }
+
+    pick() {
+        const lookingGlass = Main.createLookingGlass();
+        const inspector = new Inspector(lookingGlass);
+
+        inspector.connect('target', (me, target, x, y) => {
+            const effectName = 'lookingGlass_RedBorderEffect';
+            for (const effect of target.get_effects()) {
+                if (effect.toString().includes(effectName)) {
+                    target.remove_effect(effect);
+                }
+            }
+
+            let actor = target;
+            for (let i = 0; i < 2; i++) {
+                if (actor == null || actor instanceof Meta.WindowActor) {
+                    break;
+                }
+                actor = actor.get_parent();
+            }
+
+            if (!(actor instanceof Meta.WindowActor)) {
+                this.#sendPickedWindow(NotFoundWindowString);
+                return;
+            }
+
+            this.#sendPickedWindow(
+                actor.metaWindow.get_wm_class_instance() ?? NotFoundWindowString,
+            );
+        });
+
+        inspector.connect('closed', () => {
+            lookingGlass.close();
+        });
+    }
+
+    export() {
+        this.#dbus.export(
+            Gio.DBus.session,
+            objectPath,
+        );
+    }
+
+    unexport() {
+        this.#dbus.unexport();
     }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,6 @@
   "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/v-dimitrov/gnome-shell-extension-stealmyfocus",
   "uuid": "steal-my-focus-window@steal-my-focus-window",
-  "license": "GPL-3.0-or-later"
+  "license": "GPL-3.0-or-later",
+  "settings-schema": "org.gnome.shell.extensions.steal-my-focus-window"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,0 +1,171 @@
+import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
+
+const connection = Gio.DBus.session;
+const busName = 'org.gnome.Shell';
+const interfaceName = 'org.gnome.Shell.Extensions.StealMyFocus';
+const objectPath = '/org/gnome/shell/extensions/StealMyFocus';
+const NotFoundWindowString = "!!no-window-picked!!";
+
+export default class FocusMyWindowPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        window._settings = this.getSettings();
+
+        const page = new Adw.PreferencesPage({
+            title: _('General'),
+            icon_name: 'dialog-information-symbolic',
+        });
+        window.add(page);
+
+        const modeGroup = new Adw.PreferencesGroup({
+            title: _('Whitelist Mode'),
+            description: _('When enabled, only listed windows are allowed to be auto focused. When disabled, all windows except those listed are allowed.'),
+        });
+        page.add(modeGroup);
+
+        const modeRow = new Adw.SwitchRow({
+            title: _('Whitelist mode'),
+        });
+        modeGroup.add(modeRow);
+
+        window._settings.bind('whitelist-mode', modeRow, 'active',
+            Gio.SettingsBindFlags.DEFAULT);
+
+        const listGroup = new Adw.PreferencesGroup({
+            title: _('Window List'),
+            description: _('Case-insensitive WM_CLASS patterns to match.'),
+        });
+        page.add(listGroup);
+
+        const listBox = new Gtk.ListBox({
+            selection_mode: Gtk.SelectionMode.NONE,
+            css_classes: ['boxed-list'],
+            margin_top: 6,
+        });
+        listGroup.add(listBox);
+
+        const addRow = new Adw.EntryRow({
+            title: _('Add new pattern'),
+            show_apply_button: true
+        });
+        listGroup.add(addRow);
+
+        addRow.connect('apply', () => {
+            const text = addRow.get_text().trim();
+            if (text) {
+                const current = window._settings.get_strv('window-list');
+                if (!current.includes(text)) {
+                    current.push(text);
+                    window._settings.set_strv('window-list', current);
+                    this._rebuildList(listBox, window._settings, this);
+                }
+                addRow.set_text('');
+                // Hide apply button after user submit
+                addRow.show_apply_button = false;
+                addRow.show_apply_button = true;
+            }
+        });
+
+        const pickButton = new Gtk.Button({
+            label: _('Pick a window'),
+            valign: Gtk.Align.CENTER,
+            css_classes: ['pill'],
+        });
+        pickButton.connect('clicked', () => {
+            pickWindow().then((wmclass) => {
+                if (wmclass) {
+                const current = window._settings.get_strv('window-list');
+                if (!current.includes(wmclass)) {
+                    current.push(wmclass);
+                    window._settings.set_strv('window-list', current);
+                    this._rebuildList(listBox, window._settings, this);
+                }
+                addRow.set_text('');
+            }
+            }).catch(() => {});
+        });
+        listGroup.set_header_suffix(pickButton);
+
+        this._rebuildList(listBox, window._settings, this);
+    }
+
+    _rebuildList(listBox, settings, self) {
+        let child = listBox.get_first_child();
+        while (child) {
+            const next = child.get_next_sibling();
+            listBox.remove(child);
+            child = next;
+        }
+
+        const items = settings.get_strv('window-list');
+        for (const item of items) {
+            const row = new Adw.ActionRow({
+                title: item,
+            });
+
+            const removeBtn = new Gtk.Button({
+                icon_name: 'user-trash-symbolic',
+                valign: Gtk.Align.CENTER,
+                css_classes: ['destructive-action', 'flat'],
+            });
+            removeBtn.connect('clicked', () => {
+                const current = settings.get_strv('window-list');
+                const idx = current.indexOf(item);
+                if (idx !== -1) {
+                    current.splice(idx, 1);
+                    settings.set_strv('window-list', current);
+                    self._rebuildList(listBox, settings, self);
+                }
+            });
+            row.add_suffix(removeBtn);
+
+            listBox.append(row);
+        }
+
+        if (items.length === 0) {
+            const emptyRow = new Adw.ActionRow({
+                title: _('No entries'),
+                subtitle: _('Add a window to get started.'),
+                sensitive: false,
+            });
+            listBox.append(emptyRow);
+        }
+    }
+}
+
+async function pickWindow() {
+    connection.call(
+        busName,
+        objectPath,
+        interfaceName,
+        'pick',
+        null,
+        null,
+        Gio.DBusCallFlags.NO_AUTO_START,
+        -1,
+        null,
+        null,
+    );
+
+    return new Promise((res, rej) => {
+      const id = connection.signal_subscribe(
+        busName,
+        interfaceName,
+        'picked',
+        objectPath,
+        null,
+        Gio.DBusSignalFlags.NONE,
+        (_conn, _sender, _objectPath, _iface, _signal, params) => {
+            const val = params.get_child_value(0)?.get_string()[0];
+            if (val === NotFoundWindowString) {
+              rej(val);
+            } else {
+              res(val);
+            }
+            connection.signal_unsubscribe(id);
+        },
+      );
+    });
+}

--- a/schemas/org.gnome.shell.extensions.steal-my-focus-window.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.steal-my-focus-window.gschema.xml
@@ -1,0 +1,14 @@
+<schemalist>
+  <schema id="org.gnome.shell.extensions.steal-my-focus-window" path="/org/gnome/shell/extensions/steal-my-focus-window/">
+    <key name="whitelist-mode" type="b">
+      <default>false</default>
+      <summary>Whitelist mode</summary>
+      <description>If true, only listed windows are allowed to be auto focused. If false (default), all windows are allowed except those listed.</description>
+    </key>
+    <key name="window-list" type="as">
+      <default>[]</default>
+      <summary>Window list</summary>
+      <description>List of window WM_CLASS patterns to match. Matching is case-insensitive and checks if the pattern appears anywhere in the WM_CLASS string.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
This PR adds the ability to control **which windows** are allowed to steal focus, along with a graphical preferences window for managing the window list.

### Features

- **Whitelist/Blacklist mode** — Toggle between two behaviors:
  - *Disabled (default)*: all windows are allowed to auto-focus **except** those in the list (blacklist)
  - *Enabled*: **only** windows in the list are allowed to auto-focus (whitelist)
- **Window list** — Manage a list of `WM_CLASS` patterns. Matching is case-insensitive.
- **Interactive window picker** — A "Pick a window" button in preferences that activates the GNOME Shell Looking Glass inspector, allowing users to click any open window to add it to the list automatically. Uses D-Bus to communicate between the preferences window and the shell extension.
- **Preferences UI** — A settings window built with `Adw.PreferencesPage` and `Gtk.ListBox`, accessible via GNOME Extensions or GNOME Settings.

_This PR contains some code that generated with the assistance of an AI coding tool. All AI-generated code has been reviewed by a human and tested in a real environment (Ubuntu 26.04, GNOME Shell 50) to ensure correctness and compatibility._